### PR TITLE
Rewrite paths only in page layouts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 hexo.extend.filter.register('after_post_render', function(data) {
-	if(data.layout=='post'||data.layout=='page'||data.layout=='about'){
-		data.content=data.content.replace(/(<(img|a) *(src|href)=")(?!http:\/\/|https:\/\/|\/\/)(.*?)"/gi, '$1' +hexo.config.root+ data.path.replace(/([^\/]+).html$/g,'') + '$4"');
+  if(data.layout=='post'){
+    data.content=data.content.replace(/(<(img|a) *(src|href)=")(?!http:\/\/|https:\/\/|\/\/)(.*?)"/gi, '$1' +hexo.config.root+ data.path.replace(/([^\/]+).html$/g,'') + '$4"');
 	}
     return data;
 });


### PR DESCRIPTION
Rewrite `<a>` and `<img>`s paths only in posts. Ignore other page layouts (according to Readme this behaviour is expected).